### PR TITLE
change timeout from 10ms to 1s

### DIFF
--- a/python/src/timeplus/query.py
+++ b/python/src/timeplus/query.py
@@ -22,7 +22,7 @@ class Query(ResourceBase):
         return obj
 
     @classmethod
-    def execSQL(cls, sql, timeout=10, env=None):
+    def execSQL(cls, sql, timeout=1000, env=None):
         if env is None:
             env = Env.current()
 


### PR DESCRIPTION
if I just run `execSQL(whatever)` it uses 10ms as the default timeout. In many case it's not enough. Changing the default value to 1second. If this is a big query to scan many data, sometimes it may even take 30s