### PR TITLE
call query.delete() as last step of stop()

### DIFF
--- a/python/timeplus/query.py
+++ b/python/timeplus/query.py
@@ -91,9 +91,10 @@ class Query(ResourceBase):
         self.action("cancel")
         return self
 
-    def stop(self):
+    def stop(self, delete=True):
         self.stopped = True
-        self.delete()
+        if delete:
+            self.delete()
 
     def sink_to(self, sink):
         url = f"{self._base_url}/{self._resource_name}/{self.id()}/sinks"

--- a/python/timeplus/query.py
+++ b/python/timeplus/query.py
@@ -93,6 +93,7 @@ class Query(ResourceBase):
 
     def stop(self):
         self.stopped = True
+        self.delete()
 
     def sink_to(self, sink):
         url = f"{self._base_url}/{self._resource_name}/{self.id()}/sinks"


### PR DESCRIPTION
otherwise there could be too many query histories from API